### PR TITLE
feat: add context to all requests

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -24,6 +25,7 @@ var asciiArt = `
 `
 
 func main() {
+	ctx := context.Background()
 	if viper.GetBool("bootstrap") {
 		bootstrapAdminToken()
 		return
@@ -40,7 +42,7 @@ func main() {
 		log.Println("Migration completed successfully")
 	}
 	if viper.GetBool("server") {
-		router.Run(viper.GetInt("port"), repo)
+		router.Run(ctx, viper.GetInt("port"), repo)
 	}
 }
 

--- a/pkg/repositories/interfaces.go
+++ b/pkg/repositories/interfaces.go
@@ -1,37 +1,41 @@
 package repositories
 
-import "github.com/argon-chat/KineticaFS/pkg/models"
+import (
+	"context"
+
+	"github.com/argon-chat/KineticaFS/pkg/models"
+)
 
 type IRepository interface {
-	CreateIndices()
+	CreateIndices(ctx context.Context)
 }
 
 type IBucketRepository interface {
 	IRepository
-	GetBucketByID(id string) (*models.Bucket, error)
-	GetBucketByName(name string) (*models.Bucket, error)
-	CreateBucket(bucket *models.Bucket) error
-	UpdateBucket(bucket *models.Bucket) error
-	DeleteBucket(id string) error
-	ListBuckets() ([]*models.Bucket, error)
+	GetBucketByID(ctx context.Context, id string) (*models.Bucket, error)
+	GetBucketByName(ctx context.Context, name string) (*models.Bucket, error)
+	CreateBucket(ctx context.Context, bucket *models.Bucket) error
+	UpdateBucket(ctx context.Context, bucket *models.Bucket) error
+	DeleteBucket(ctx context.Context, id string) error
+	ListBuckets(ctx context.Context) ([]*models.Bucket, error)
 }
 
 type IFileRepository interface {
 	IRepository
-	GetFileByID(id string) (*models.File, error)
-	GetFileByName(bucketID, name string) (*models.File, error)
-	CreateFile(file *models.File) error
-	UpdateFile(file *models.File) error
-	DeleteFile(id string) error
-	ListFiles(bucketID string) ([]*models.File, error)
+	GetFileByID(ctx context.Context, id string) (*models.File, error)
+	GetFileByName(ctx context.Context, bucketID, name string) (*models.File, error)
+	CreateFile(ctx context.Context, file *models.File) error
+	UpdateFile(ctx context.Context, file *models.File) error
+	DeleteFile(ctx context.Context, id string) error
+	ListFiles(ctx context.Context, bucketID string) ([]*models.File, error)
 }
 
 type IServiceTokenRepository interface {
 	IRepository
-	GetAllServiceTokens() ([]*models.ServiceToken, error)
-	GetServiceTokenById(id string) (*models.ServiceToken, error)
-	GetServiceTokenByAccessKey(accessKey string) (*models.ServiceToken, error)
-	GetServiceTokenByName(name string) (*models.ServiceToken, error)
-	CreateServiceToken(token *models.ServiceToken) error
-	RevokeServiceToken(id string) error
+	GetAllServiceTokens(ctx context.Context) ([]*models.ServiceToken, error)
+	GetServiceTokenById(ctx context.Context, id string) (*models.ServiceToken, error)
+	GetServiceTokenByAccessKey(ctx context.Context, accessKey string) (*models.ServiceToken, error)
+	GetServiceTokenByName(ctx context.Context, name string) (*models.ServiceToken, error)
+	CreateServiceToken(ctx context.Context, token *models.ServiceToken) error
+	RevokeServiceToken(ctx context.Context, id string) error
 }

--- a/pkg/repositories/postgres/files.go
+++ b/pkg/repositories/postgres/files.go
@@ -1,6 +1,7 @@
 package postgres
 
 import (
+	"context"
 	"database/sql"
 	"log"
 
@@ -15,35 +16,35 @@ func NewPostgresFileRepository(session *sql.DB) *PostgresFileRepository {
 	return &PostgresFileRepository{session: session}
 }
 
-func (s *PostgresFileRepository) CreateIndices() {
+func (s *PostgresFileRepository) CreateIndices(ctx context.Context) {
 	indexQueries := []string{}
 	for _, indexQuery := range indexQueries {
 		log.Printf("Executing index creation query: %s", indexQuery)
-		if _, err := s.session.Exec(indexQuery); err != nil {
+		if _, err := s.session.ExecContext(ctx, indexQuery); err != nil {
 			log.Printf("Error creating index: %v", err)
 		}
 	}
 }
-func (p *PostgresFileRepository) GetFileByID(id string) (*models.File, error) {
+func (p *PostgresFileRepository) GetFileByID(ctx context.Context, id string) (*models.File, error) {
 	panic("implement me")
 }
 
-func (p *PostgresFileRepository) GetFileByName(bucketID, name string) (*models.File, error) {
+func (p *PostgresFileRepository) GetFileByName(ctx context.Context, bucketID, name string) (*models.File, error) {
 	panic("implement me")
 }
 
-func (p *PostgresFileRepository) CreateFile(file *models.File) error {
+func (p *PostgresFileRepository) CreateFile(ctx context.Context, file *models.File) error {
 	panic("implement me")
 }
 
-func (p *PostgresFileRepository) UpdateFile(file *models.File) error {
+func (p *PostgresFileRepository) UpdateFile(ctx context.Context, file *models.File) error {
 	panic("implement me")
 }
 
-func (p *PostgresFileRepository) DeleteFile(id string) error {
+func (p *PostgresFileRepository) DeleteFile(ctx context.Context, id string) error {
 	panic("implement me")
 }
 
-func (p *PostgresFileRepository) ListFiles(bucketID string) ([]*models.File, error) {
+func (p *PostgresFileRepository) ListFiles(ctx context.Context, bucketID string) ([]*models.File, error) {
 	panic("implement me")
 }

--- a/pkg/repositories/scylla/buckets.go
+++ b/pkg/repositories/scylla/buckets.go
@@ -1,6 +1,7 @@
 package scylla
 
 import (
+	"context"
 	"log"
 	"time"
 
@@ -34,20 +35,21 @@ func NewScyllaBucketRepository(session *gocql.Session) *ScyllaBucketRepository {
 	return &ScyllaBucketRepository{session: session}
 }
 
-func (s *ScyllaBucketRepository) CreateIndices() {
+func (s *ScyllaBucketRepository) CreateIndices(ctx context.Context) {
 	indexQueries := []string{
 		"CREATE INDEX IF NOT EXISTS bucket_name_idx ON bucket (name)",
 		"CREATE INDEX IF NOT EXISTS bucket_region_idx ON bucket (region)",
 	}
 	for _, indexQuery := range indexQueries {
 		log.Printf("Executing index creation query: %s", indexQuery)
-		if err := s.session.Query(indexQuery).Exec(); err != nil {
+		if err := s.session.Query(indexQuery).WithContext(ctx).Exec(); err != nil {
 			log.Printf("Error creating index: %v", err)
 		}
 	}
 }
-func (s *ScyllaBucketRepository) GetBucketByID(id string) (*models.Bucket, error) {
-	query := s.session.Query("select id, name, region, endpoint, s3provider, accesskey, secretkey, storagetype, usessl, customconfig, createdat, updatedat from bucket where id = ?", id)
+func (s *ScyllaBucketRepository) GetBucketByID(ctx context.Context, id string) (*models.Bucket, error) {
+	query := s.session.Query("select id, name, region, endpoint, s3provider, accesskey, secretkey, storagetype, usessl, customconfig, createdat, updatedat from bucket where id = ?", id).
+		WithContext(ctx)
 	var bucket models.Bucket
 	var storageType int8
 	var useSSL bool
@@ -62,8 +64,9 @@ func (s *ScyllaBucketRepository) GetBucketByID(id string) (*models.Bucket, error
 	return &bucket, nil
 }
 
-func (s *ScyllaBucketRepository) GetBucketByName(name string) (*models.Bucket, error) {
-	query := s.session.Query("select id, name, region, endpoint, s3provider, accesskey, secretkey, storagetype, usessl, customconfig, createdat, updatedat from bucket where name = ?", name)
+func (s *ScyllaBucketRepository) GetBucketByName(ctx context.Context, name string) (*models.Bucket, error) {
+	query := s.session.Query("select id, name, region, endpoint, s3provider, accesskey, secretkey, storagetype, usessl, customconfig, createdat, updatedat from bucket where name = ?", name).
+		WithContext(ctx)
 	var bucket models.Bucket
 	var storageType int8
 	var useSSL bool
@@ -78,31 +81,33 @@ func (s *ScyllaBucketRepository) GetBucketByName(name string) (*models.Bucket, e
 	return &bucket, nil
 }
 
-func (s *ScyllaBucketRepository) CreateBucket(bucket *models.Bucket) error {
+func (s *ScyllaBucketRepository) CreateBucket(ctx context.Context, bucket *models.Bucket) error {
 	now := time.Now()
 	bucket.CreatedAt = now
 	bucket.UpdatedAt = now
 	bucket.ID = uuid.NewString()
 	query := s.session.Query(
 		"insert into bucket (id, name, region, endpoint, s3provider, accesskey, secretkey, storagetype, usessl, customconfig, createdat, updatedat) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-		bucket.ID, bucket.Name, bucket.Region, bucket.Endpoint, bucket.S3Provider, bucket.AccessKey, bucket.SecretKey, bucket.StorageType, bucket.UseSSL, bucket.CustomConfig, bucket.CreatedAt, bucket.UpdatedAt)
+		bucket.ID, bucket.Name, bucket.Region, bucket.Endpoint, bucket.S3Provider, bucket.AccessKey, bucket.SecretKey, bucket.StorageType, bucket.UseSSL, bucket.CustomConfig, bucket.CreatedAt, bucket.UpdatedAt).
+		WithContext(ctx)
 	return query.Exec()
 }
 
-func (s *ScyllaBucketRepository) UpdateBucket(bucket *models.Bucket) error {
+func (s *ScyllaBucketRepository) UpdateBucket(ctx context.Context, bucket *models.Bucket) error {
 	query := s.session.Query(
 		"update bucket set name = ?, region = ?, endpoint = ?, s3provider = ?, accesskey = ?, secretkey = ?, storagetype = ?, usessl = ?, customconfig = ?, updatedat = ? where id = ?",
-		bucket.Name, bucket.Region, bucket.Endpoint, bucket.S3Provider, bucket.AccessKey, bucket.SecretKey, bucket.StorageType, bucket.UseSSL, bucket.CustomConfig, time.Now(), bucket.ID)
+		bucket.Name, bucket.Region, bucket.Endpoint, bucket.S3Provider, bucket.AccessKey, bucket.SecretKey, bucket.StorageType, bucket.UseSSL, bucket.CustomConfig, time.Now(), bucket.ID).
+		WithContext(ctx)
 	return query.Exec()
 }
 
-func (s *ScyllaBucketRepository) DeleteBucket(id string) error {
-	return s.session.Query("delete from bucket where id = ?", id).Exec()
+func (s *ScyllaBucketRepository) DeleteBucket(ctx context.Context, id string) error {
+	return s.session.Query("delete from bucket where id = ?", id).WithContext(ctx).Exec()
 }
 
-func (s *ScyllaBucketRepository) ListBuckets() ([]*models.Bucket, error) {
+func (s *ScyllaBucketRepository) ListBuckets(ctx context.Context) ([]*models.Bucket, error) {
 	var buckets []*models.Bucket
-	iter := s.session.Query("select id, name, region, endpoint, s3provider, accesskey, secretkey, storagetype, usessl, customconfig, createdat, updatedat from bucket").Iter()
+	iter := s.session.Query("select id, name, region, endpoint, s3provider, accesskey, secretkey, storagetype, usessl, customconfig, createdat, updatedat from bucket").WithContext(ctx).Iter()
 	var bucket models.Bucket
 	var storageType int8
 	var useSSL bool

--- a/pkg/repositories/scylla/files.go
+++ b/pkg/repositories/scylla/files.go
@@ -1,6 +1,7 @@
 package scylla
 
 import (
+	"context"
 	"log"
 
 	"github.com/argon-chat/KineticaFS/pkg/models"
@@ -15,36 +16,36 @@ func NewScyllaFileRepository(session *gocql.Session) *ScyllaFileRepository {
 	return &ScyllaFileRepository{session: session}
 }
 
-func (s *ScyllaFileRepository) CreateIndices() {
+func (s *ScyllaFileRepository) CreateIndices(ctx context.Context) {
 	indexQueries := []string{}
 	for _, indexQuery := range indexQueries {
 		log.Printf("Executing index creation query: %s", indexQuery)
-		if err := s.session.Query(indexQuery).Exec(); err != nil {
+		if err := s.session.Query(indexQuery).WithContext(ctx).Exec(); err != nil {
 			log.Printf("Error creating index: %v", err)
 		}
 	}
 }
 
-func (s *ScyllaFileRepository) GetFileByID(id string) (*models.File, error) {
+func (s *ScyllaFileRepository) GetFileByID(ctx context.Context, id string) (*models.File, error) {
 	panic("implement me")
 }
 
-func (s *ScyllaFileRepository) GetFileByName(bucketID, name string) (*models.File, error) {
+func (s *ScyllaFileRepository) GetFileByName(ctx context.Context, bucketID, name string) (*models.File, error) {
 	panic("implement me")
 }
 
-func (s *ScyllaFileRepository) CreateFile(file *models.File) error {
+func (s *ScyllaFileRepository) CreateFile(ctx context.Context, file *models.File) error {
 	panic("implement me")
 }
 
-func (s *ScyllaFileRepository) UpdateFile(file *models.File) error {
+func (s *ScyllaFileRepository) UpdateFile(ctx context.Context, file *models.File) error {
 	panic("implement me")
 }
 
-func (s *ScyllaFileRepository) DeleteFile(id string) error {
+func (s *ScyllaFileRepository) DeleteFile(ctx context.Context, id string) error {
 	panic("implement me")
 }
 
-func (s *ScyllaFileRepository) ListFiles(bucketID string) ([]*models.File, error) {
+func (s *ScyllaFileRepository) ListFiles(ctx context.Context, bucketID string) ([]*models.File, error) {
 	panic("implement me")
 }

--- a/pkg/repositories/scylla/serviceTokens.go
+++ b/pkg/repositories/scylla/serviceTokens.go
@@ -1,6 +1,7 @@
 package scylla
 
 import (
+	"context"
 	"log"
 	"time"
 
@@ -28,21 +29,22 @@ func NewScyllaServiceTokenRepository(session *gocql.Session) *ScyllaServiceToken
 	return &ScyllaServiceTokenRepository{session: session}
 }
 
-func (s *ScyllaServiceTokenRepository) CreateIndices() {
+func (s *ScyllaServiceTokenRepository) CreateIndices(ctx context.Context) {
 	indexQueries := []string{
 		"CREATE INDEX IF NOT EXISTS servicetoken_name_idx ON servicetoken (name)",
 		"CREATE INDEX IF NOT EXISTS servicetoken_accesskey_idx ON servicetoken (accesskey)",
 	}
 	for _, indexQuery := range indexQueries {
 		log.Printf("Executing index creation query: %s", indexQuery)
-		if err := s.session.Query(indexQuery).Exec(); err != nil {
+		if err := s.session.Query(indexQuery).WithContext(ctx).Exec(); err != nil {
 			log.Printf("Error creating index: %v", err)
 		}
 	}
 }
 
-func (s *ScyllaServiceTokenRepository) GetServiceTokenByAccessKey(accessKey string) (*models.ServiceToken, error) {
-	query := s.session.Query("select id, name, accesskey, tokentype, createdat, updatedat from servicetoken where accesskey = ?", accessKey)
+func (s *ScyllaServiceTokenRepository) GetServiceTokenByAccessKey(ctx context.Context, accessKey string) (*models.ServiceToken, error) {
+	query := s.session.Query("select id, name, accesskey, tokentype, createdat, updatedat from servicetoken where accesskey = ?", accessKey).
+		WithContext(ctx)
 	var token models.ServiceToken
 	var tokenType int8
 	if err := query.Scan(&token.ID, &token.Name, &token.AccessKey, &tokenType, &token.CreatedAt, &token.UpdatedAt); err != nil {
@@ -55,9 +57,11 @@ func (s *ScyllaServiceTokenRepository) GetServiceTokenByAccessKey(accessKey stri
 	return &token, nil
 }
 
-func (s *ScyllaServiceTokenRepository) GetAllServiceTokens() ([]*models.ServiceToken, error) {
+func (s *ScyllaServiceTokenRepository) GetAllServiceTokens(ctx context.Context) ([]*models.ServiceToken, error) {
 	var tokens []*models.ServiceToken
-	iter := s.session.Query("select id, name, accesskey, tokentype, createdat, updatedat from servicetoken").Iter()
+	iter := s.session.Query("select id, name, accesskey, tokentype, createdat, updatedat from servicetoken").
+		WithContext(ctx).
+		Iter()
 	var token models.ServiceToken
 	var tokenType int8
 	for iter.Scan(&token.ID, &token.Name, &token.AccessKey, &tokenType, &token.CreatedAt, &token.UpdatedAt) {
@@ -78,8 +82,9 @@ func (s *ScyllaServiceTokenRepository) GetAllServiceTokens() ([]*models.ServiceT
 	return tokens, nil
 }
 
-func (s *ScyllaServiceTokenRepository) GetServiceTokenById(id string) (*models.ServiceToken, error) {
-	query := s.session.Query("select id, name, accesskey, tokentype, createdat, updatedat from servicetoken where id = ?", id)
+func (s *ScyllaServiceTokenRepository) GetServiceTokenById(ctx context.Context, id string) (*models.ServiceToken, error) {
+	query := s.session.Query("select id, name, accesskey, tokentype, createdat, updatedat from servicetoken where id = ?", id).
+		WithContext(ctx)
 	var token models.ServiceToken
 	var tokenType int8
 	if err := query.Scan(&token.ID, &token.Name, &token.AccessKey, &tokenType, &token.CreatedAt, &token.UpdatedAt); err != nil {
@@ -92,8 +97,8 @@ func (s *ScyllaServiceTokenRepository) GetServiceTokenById(id string) (*models.S
 	return &token, nil
 }
 
-func (s *ScyllaServiceTokenRepository) GetServiceTokenByName(name string) (*models.ServiceToken, error) {
-	query := s.session.Query("select id, name, accesskey, tokentype, createdat, updatedat from servicetoken where name = ?", name)
+func (s *ScyllaServiceTokenRepository) GetServiceTokenByName(ctx context.Context, name string) (*models.ServiceToken, error) {
+	query := s.session.Query("select id, name, accesskey, tokentype, createdat, updatedat from servicetoken where name = ?", name).WithContext(ctx)
 	var token models.ServiceToken
 	var tokenType int8
 	if err := query.Scan(&token.ID, &token.Name, &token.AccessKey, &tokenType, &token.CreatedAt, &token.UpdatedAt); err != nil {
@@ -106,16 +111,16 @@ func (s *ScyllaServiceTokenRepository) GetServiceTokenByName(name string) (*mode
 	return &token, nil
 }
 
-func (s *ScyllaServiceTokenRepository) CreateServiceToken(token *models.ServiceToken) error {
+func (s *ScyllaServiceTokenRepository) CreateServiceToken(ctx context.Context, token *models.ServiceToken) error {
 	token.ID = uuid.NewString()
 	token.CreatedAt = time.Now()
 	token.UpdatedAt = token.CreatedAt
 	query := s.session.Query(
 		"insert into servicetoken (id, name, accesskey, tokentype, createdat, updatedat) values (?, ?, ?, ?, ?, ?)",
-		token.ID, token.Name, token.AccessKey, int8(token.TokenType), token.CreatedAt, token.UpdatedAt)
+		token.ID, token.Name, token.AccessKey, int8(token.TokenType), token.CreatedAt, token.UpdatedAt).WithContext(ctx)
 	return query.Exec()
 }
 
-func (s *ScyllaServiceTokenRepository) RevokeServiceToken(id string) error {
+func (s *ScyllaServiceTokenRepository) RevokeServiceToken(ctx context.Context, id string) error {
 	return s.session.Query("delete from servicetoken where id = ?", id).Exec()
 }

--- a/pkg/repositories/scylla/serviceTokens.go
+++ b/pkg/repositories/scylla/serviceTokens.go
@@ -122,5 +122,5 @@ func (s *ScyllaServiceTokenRepository) CreateServiceToken(ctx context.Context, t
 }
 
 func (s *ScyllaServiceTokenRepository) RevokeServiceToken(ctx context.Context, id string) error {
-	return s.session.Query("delete from servicetoken where id = ?", id).Exec()
+	return s.session.Query("delete from servicetoken where id = ?", id).WithContext(ctx).Exec()
 }

--- a/pkg/router/buckets.go
+++ b/pkg/router/buckets.go
@@ -51,7 +51,8 @@ func CreateBucketHandler(c *gin.Context) {
 		})
 		return
 	}
-	existing, err := applicationRepository.Buckets.GetBucketByName(bucket.Name)
+	ctx := c.Request.Context()
+	existing, err := applicationRepository.Buckets.GetBucketByName(ctx, bucket.Name)
 	if err != nil {
 		c.JSON(400, ErrorResponse{
 			Code:    400,
@@ -66,7 +67,7 @@ func CreateBucketHandler(c *gin.Context) {
 		})
 		return
 	}
-	err = applicationRepository.Buckets.CreateBucket(&bucket)
+	err = applicationRepository.Buckets.CreateBucket(ctx, &bucket)
 	if err != nil {
 		c.JSON(400, ErrorResponse{
 			Code:    400,
@@ -88,7 +89,7 @@ func CreateBucketHandler(c *gin.Context) {
 // @Failure 403 {object} router.ErrorResponse "Forbidden - Admin only"
 // @Router /v1/bucket/ [get]
 func ListBucketsHandler(c *gin.Context) {
-	buckets, err := applicationRepository.Buckets.ListBuckets()
+	buckets, err := applicationRepository.Buckets.ListBuckets(c.Request.Context())
 	if err != nil {
 		c.JSON(500, ErrorResponse{
 			Code:    500,
@@ -113,7 +114,7 @@ func ListBucketsHandler(c *gin.Context) {
 // @Router /v1/bucket/{id} [get]
 func GetBucketHandler(c *gin.Context) {
 	id := c.Param("id")
-	bucket, err := applicationRepository.Buckets.GetBucketByID(id)
+	bucket, err := applicationRepository.Buckets.GetBucketByID(c.Request.Context(), id)
 	if err != nil {
 		c.JSON(500, ErrorResponse{
 			Code:    500,
@@ -156,7 +157,9 @@ func UpdateBucketHandler(c *gin.Context) {
 		})
 		return
 	}
-	bucket, err := applicationRepository.Buckets.GetBucketByID(id)
+
+	ctx := c.Request.Context()
+	bucket, err := applicationRepository.Buckets.GetBucketByID(ctx, id)
 	if err != nil {
 		c.JSON(500, ErrorResponse{
 			Code:    500,
@@ -180,7 +183,7 @@ func UpdateBucketHandler(c *gin.Context) {
 	bucket.S3Provider = req.S3Provider
 	bucket.CustomConfig = req.CustomConfig
 	bucket.StorageType = req.StorageType
-	err = applicationRepository.Buckets.UpdateBucket(bucket)
+	err = applicationRepository.Buckets.UpdateBucket(ctx, bucket)
 	if err != nil {
 		c.JSON(400, ErrorResponse{
 			Code:    400,
@@ -204,7 +207,8 @@ func UpdateBucketHandler(c *gin.Context) {
 // @Router /v1/bucket/{id} [delete]
 func DeleteBucketHandler(c *gin.Context) {
 	id := c.Param("id")
-	bucket, err := applicationRepository.Buckets.GetBucketByID(id)
+	ctx := c.Request.Context()
+	bucket, err := applicationRepository.Buckets.GetBucketByID(ctx, id)
 	if err != nil {
 		c.JSON(500, ErrorResponse{
 			Code:    500,
@@ -219,7 +223,7 @@ func DeleteBucketHandler(c *gin.Context) {
 		})
 		return
 	}
-	err = applicationRepository.Buckets.DeleteBucket(id)
+	err = applicationRepository.Buckets.DeleteBucket(ctx, id)
 	if err != nil {
 		c.JSON(500, ErrorResponse{
 			Code:    500,

--- a/pkg/router/main.go
+++ b/pkg/router/main.go
@@ -1,6 +1,7 @@
 package router
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/argon-chat/KineticaFS/pkg/repositories"
@@ -13,8 +14,8 @@ var router = gin.Default()
 
 var applicationRepository *repositories.ApplicationRepository
 
-func Run(port int, repo *repositories.ApplicationRepository) {
-	initializeRepo(repo)
+func Run(ctx context.Context, port int, repo *repositories.ApplicationRepository) {
+	initializeRepo(ctx, repo)
 	getRoutes()
 	router.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
 	err := router.Run(fmt.Sprintf(":%d", port))
@@ -28,11 +29,11 @@ func getRoutes() {
 	addV1Routes(v1)
 }
 
-func initializeRepo(repo *repositories.ApplicationRepository) {
+func initializeRepo(ctx context.Context, repo *repositories.ApplicationRepository) {
 	applicationRepository = repo
-	applicationRepository.ServiceTokens.CreateIndices()
-	applicationRepository.Buckets.CreateIndices()
-	applicationRepository.Files.CreateIndices()
+	applicationRepository.ServiceTokens.CreateIndices(ctx)
+	applicationRepository.Buckets.CreateIndices(ctx)
+	applicationRepository.Files.CreateIndices(ctx)
 }
 
 func addV1Routes(v1 *gin.RouterGroup) {

--- a/pkg/router/middlewares.go
+++ b/pkg/router/middlewares.go
@@ -15,7 +15,7 @@ func AuthMiddleware(c *gin.Context) {
 		return
 	}
 
-	serviceToken, err := applicationRepository.ServiceTokens.GetServiceTokenByAccessKey(token)
+	serviceToken, err := applicationRepository.ServiceTokens.GetServiceTokenByAccessKey(c.Request.Context(), token)
 	if err != nil {
 		c.AbortWithStatusJSON(500, ErrorResponse{
 			Code:    500,

--- a/pkg/router/serviceTokens.go
+++ b/pkg/router/serviceTokens.go
@@ -38,7 +38,8 @@ func AddServiceTokenRoutes(v1 *gin.RouterGroup) {
 // @Failure 409 {object} router.ErrorResponse "Admin token already exists"
 // @Router /v1/st/bootstrap [post]
 func CreateAdminServiceTokenHandler(c *gin.Context) {
-	existingToken, err := applicationRepository.ServiceTokens.GetServiceTokenByName("admin")
+	ctx := c.Request.Context()
+	existingToken, err := applicationRepository.ServiceTokens.GetServiceTokenByName(ctx, "admin")
 	if err != nil {
 		c.JSON(400, ErrorResponse{
 			Code:    400,
@@ -58,7 +59,7 @@ func CreateAdminServiceTokenHandler(c *gin.Context) {
 		AccessKey: fmt.Sprintf("%x", sha256.Sum256([]byte(uuid.NewString()))),
 		TokenType: models.AdminToken | models.UserToken,
 	}
-	err = applicationRepository.ServiceTokens.CreateServiceToken(&token)
+	err = applicationRepository.ServiceTokens.CreateServiceToken(ctx, &token)
 	if err != nil {
 		c.JSON(400, ErrorResponse{
 			Code:    400,
@@ -79,7 +80,7 @@ func CreateAdminServiceTokenHandler(c *gin.Context) {
 // @Failure 403 {object} router.ErrorResponse "Forbidden - Admin only"
 // @Router /v1/st/ [get]
 func ListAllServiceTokens(c *gin.Context) {
-	tokens, err := applicationRepository.ServiceTokens.GetAllServiceTokens()
+	tokens, err := applicationRepository.ServiceTokens.GetAllServiceTokens(c.Request.Context())
 	if err != nil {
 		c.JSON(500, ErrorResponse{
 			Code:    500,
@@ -112,7 +113,8 @@ func CreateServiceTokenHandler(c *gin.Context) {
 		})
 		return
 	}
-	existingToken, err := applicationRepository.ServiceTokens.GetServiceTokenByName(req.Name)
+	ctx := c.Request.Context()
+	existingToken, err := applicationRepository.ServiceTokens.GetServiceTokenByName(ctx, req.Name)
 	if err != nil {
 		c.JSON(400, ErrorResponse{
 			Code:    400,
@@ -132,7 +134,7 @@ func CreateServiceTokenHandler(c *gin.Context) {
 		AccessKey: fmt.Sprintf("%x", sha256.Sum256([]byte(uuid.NewString()))),
 		TokenType: models.UserToken,
 	}
-	err = applicationRepository.ServiceTokens.CreateServiceToken(&token)
+	err = applicationRepository.ServiceTokens.CreateServiceToken(ctx, &token)
 	if err != nil {
 		c.JSON(400, ErrorResponse{
 			Code:    400,
@@ -157,7 +159,7 @@ func CreateServiceTokenHandler(c *gin.Context) {
 // @Router /v1/st/{id} [get]
 func GetServiceTokenHandler(c *gin.Context) {
 	id := c.Param("id")
-	token, err := applicationRepository.ServiceTokens.GetServiceTokenById(id)
+	token, err := applicationRepository.ServiceTokens.GetServiceTokenById(c.Request.Context(), id)
 	if err != nil {
 		c.JSON(500, ErrorResponse{
 			Code:    500,
@@ -188,7 +190,8 @@ func GetServiceTokenHandler(c *gin.Context) {
 // @Router /v1/st/{id} [delete]
 func DeleteServiceTokenHandler(c *gin.Context) {
 	id := c.Param("id")
-	token, err := applicationRepository.ServiceTokens.GetServiceTokenById(id)
+	ctx := c.Request.Context()
+	token, err := applicationRepository.ServiceTokens.GetServiceTokenById(ctx, id)
 	if err != nil {
 		c.JSON(500, ErrorResponse{
 			Code:    500,
@@ -210,7 +213,7 @@ func DeleteServiceTokenHandler(c *gin.Context) {
 		})
 		return
 	}
-	err = applicationRepository.ServiceTokens.RevokeServiceToken(id)
+	err = applicationRepository.ServiceTokens.RevokeServiceToken(ctx, id)
 	if err != nil {
 		c.JSON(500, ErrorResponse{
 			Code:    500,


### PR DESCRIPTION
# feat: add context.Context to long-running calls

Added `context.Context` to all long-running operations to support cancellation and timeouts.  
Functions and methods now propagate the context through the call chain, improving execution control and allowing operations to terminate gracefully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Request handling now propagates request-scoped context, enabling cancellation and timeouts across the app.
- Bug Fixes
  - Improved startup error reporting to avoid silent failures.
  - More consistent "not found" responses for token lookups.
- Refactor
  - Migrated routing and data operations to context-aware calls for safer, more reliable execution.
  - Unified context propagation from incoming requests through service and storage layers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->