### PR TITLE
Refactor: remove global dependencies and wrap routes in a router struct

### DIFF
--- a/pkg/repositories/postgres/buckets.go
+++ b/pkg/repositories/postgres/buckets.go
@@ -112,14 +112,14 @@ func (p *PostgresBucketRepository) ListBuckets(ctx context.Context) ([]*models.B
 	defer rows.Close()
 	var buckets []*models.Bucket
 	for rows.Next() {
-		var bucket models.Bucket
+		bucket := &models.Bucket{}
 		var storageType int8
 		err := rows.Scan(&bucket.ID, &bucket.Name, &bucket.Region, &bucket.Endpoint, &bucket.S3Provider, &bucket.AccessKey, &bucket.SecretKey, &storageType, &bucket.UseSSL, &bucket.CustomConfig, &bucket.CreatedAt, &bucket.UpdatedAt)
 		if err != nil {
 			return nil, err
 		}
 		bucket.StorageType = models.StorageType(storageType)
-		buckets = append(buckets, &bucket)
+		buckets = append(buckets, bucket)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/pkg/repositories/postgres/serviceTokens.go
+++ b/pkg/repositories/postgres/serviceTokens.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"log"
 	"time"
 
@@ -48,7 +49,7 @@ func (p *PostgresServiceTokenRepository) GetServiceTokenById(ctx context.Context
 	var token models.ServiceToken
 	var tokenType int8
 	err := row.Scan(&token.ID, &token.Name, &token.AccessKey, &tokenType, &token.CreatedAt, &token.UpdatedAt)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {
@@ -73,15 +74,7 @@ func (s *PostgresServiceTokenRepository) GetAllServiceTokens(ctx context.Context
 			return nil, err
 		}
 		token.TokenType = models.TokenType(tokenType)
-		newToken := &models.ServiceToken{
-			Name:      token.Name,
-			AccessKey: token.AccessKey,
-			TokenType: token.TokenType,
-		}
-		newToken.ID = token.ID
-		newToken.CreatedAt = token.CreatedAt
-		newToken.UpdatedAt = token.UpdatedAt
-		tokens = append(tokens, newToken)
+		tokens = append(tokens, &token)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -93,7 +86,7 @@ func (s *PostgresServiceTokenRepository) GetServiceTokenByAccessKey(ctx context.
 	var token models.ServiceToken
 	var tokenType int8
 	err := row.Scan(&token.ID, &token.Name, &token.AccessKey, &tokenType, &token.CreatedAt, &token.UpdatedAt)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {
@@ -108,7 +101,7 @@ func (p *PostgresServiceTokenRepository) GetServiceTokenByName(ctx context.Conte
 	var token models.ServiceToken
 	var tokenType int8
 	err := row.Scan(&token.ID, &token.Name, &token.AccessKey, &tokenType, &token.CreatedAt, &token.UpdatedAt)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {

--- a/pkg/repositories/postgres/serviceTokens.go
+++ b/pkg/repositories/postgres/serviceTokens.go
@@ -67,14 +67,14 @@ func (s *PostgresServiceTokenRepository) GetAllServiceTokens(ctx context.Context
 	defer rows.Close()
 	var tokens []*models.ServiceToken
 	for rows.Next() {
-		var token models.ServiceToken
+		token := &models.ServiceToken{}
 		var tokenType int8
 		err := rows.Scan(&token.ID, &token.Name, &token.AccessKey, &tokenType, &token.CreatedAt, &token.UpdatedAt)
 		if err != nil {
 			return nil, err
 		}
 		token.TokenType = models.TokenType(tokenType)
-		tokens = append(tokens, &token)
+		tokens = append(tokens, token)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/pkg/repositories/scylla/buckets.go
+++ b/pkg/repositories/scylla/buckets.go
@@ -112,7 +112,7 @@ func (s *ScyllaBucketRepository) ListBuckets(ctx context.Context) ([]*models.Buc
 		bucket := &models.Bucket{}
 		var storageType int8
 
-		if iter.Scan(&bucket.ID, &bucket.Name, &bucket.Region, &bucket.Endpoint, &bucket.S3Provider, &bucket.AccessKey, &bucket.SecretKey, &storageType, &bucket.UseSSL, &bucket.CustomConfig, &bucket.CreatedAt, &bucket.UpdatedAt) {
+		if !iter.Scan(&bucket.ID, &bucket.Name, &bucket.Region, &bucket.Endpoint, &bucket.S3Provider, &bucket.AccessKey, &bucket.SecretKey, &storageType, &bucket.UseSSL, &bucket.CustomConfig, &bucket.CreatedAt, &bucket.UpdatedAt) {
 			break
 		}
 

--- a/pkg/repositories/scylla/buckets.go
+++ b/pkg/repositories/scylla/buckets.go
@@ -107,14 +107,13 @@ func (s *ScyllaBucketRepository) ListBuckets(ctx context.Context) ([]*models.Buc
 
 	estimatedSize := iter.NumRows()
 	buckets := make([]*models.Bucket, 0, estimatedSize)
-	scanner := iter.Scanner()
 
-	for scanner.Next() {
+	for {
 		bucket := &models.Bucket{}
 		var storageType int8
 
-		if err := scanner.Scan(&bucket.ID, &bucket.Name, &bucket.Region, &bucket.Endpoint, &bucket.S3Provider, &bucket.AccessKey, &bucket.SecretKey, &storageType, &bucket.UseSSL, &bucket.CustomConfig, &bucket.CreatedAt, &bucket.UpdatedAt); err != nil {
-			return nil, err
+		if iter.Scan(&bucket.ID, &bucket.Name, &bucket.Region, &bucket.Endpoint, &bucket.S3Provider, &bucket.AccessKey, &bucket.SecretKey, &storageType, &bucket.UseSSL, &bucket.CustomConfig, &bucket.CreatedAt, &bucket.UpdatedAt) {
+			break
 		}
 
 		bucket.StorageType = models.StorageType(storageType)

--- a/pkg/repositories/scylla/serviceTokens.go
+++ b/pkg/repositories/scylla/serviceTokens.go
@@ -2,6 +2,7 @@ package scylla
 
 import (
 	"context"
+	"errors"
 	"log"
 	"time"
 
@@ -48,7 +49,7 @@ func (s *ScyllaServiceTokenRepository) GetServiceTokenByAccessKey(ctx context.Co
 	var token models.ServiceToken
 	var tokenType int8
 	if err := query.Scan(&token.ID, &token.Name, &token.AccessKey, &tokenType, &token.CreatedAt, &token.UpdatedAt); err != nil {
-		if err == gocql.ErrNotFound {
+		if errors.Is(err, gocql.ErrNotFound) {
 			return nil, nil
 		}
 		return nil, err
@@ -66,15 +67,7 @@ func (s *ScyllaServiceTokenRepository) GetAllServiceTokens(ctx context.Context) 
 	var tokenType int8
 	for iter.Scan(&token.ID, &token.Name, &token.AccessKey, &tokenType, &token.CreatedAt, &token.UpdatedAt) {
 		token.TokenType = models.TokenType(tokenType)
-		newToken := &models.ServiceToken{
-			Name:      token.Name,
-			AccessKey: token.AccessKey,
-			TokenType: token.TokenType,
-		}
-		newToken.ID = token.ID
-		newToken.CreatedAt = token.CreatedAt
-		newToken.UpdatedAt = token.UpdatedAt
-		tokens = append(tokens, newToken)
+		tokens = append(tokens, &token)
 	}
 	if err := iter.Close(); err != nil {
 		return nil, err
@@ -88,7 +81,7 @@ func (s *ScyllaServiceTokenRepository) GetServiceTokenById(ctx context.Context, 
 	var token models.ServiceToken
 	var tokenType int8
 	if err := query.Scan(&token.ID, &token.Name, &token.AccessKey, &tokenType, &token.CreatedAt, &token.UpdatedAt); err != nil {
-		if err == gocql.ErrNotFound {
+		if errors.Is(err, gocql.ErrNotFound) {
 			return nil, nil
 		}
 		return nil, err
@@ -102,7 +95,7 @@ func (s *ScyllaServiceTokenRepository) GetServiceTokenByName(ctx context.Context
 	var token models.ServiceToken
 	var tokenType int8
 	if err := query.Scan(&token.ID, &token.Name, &token.AccessKey, &tokenType, &token.CreatedAt, &token.UpdatedAt); err != nil {
-		if err == gocql.ErrNotFound {
+		if errors.Is(err, gocql.ErrNotFound) {
 			return nil, nil
 		}
 		return nil, err

--- a/pkg/repositories/scylla/serviceTokens.go
+++ b/pkg/repositories/scylla/serviceTokens.go
@@ -65,13 +65,11 @@ func (s *ScyllaServiceTokenRepository) GetAllServiceTokens(ctx context.Context) 
 
 	estimatedSize := iter.NumRows()
 	tokens := make([]*models.ServiceToken, 0, estimatedSize)
-	scanner := iter.Scanner()
-
-	for scanner.Next() {
+	for {
 		token := &models.ServiceToken{}
 		var tokenType int8
-		if err := scanner.Scan(&token.ID, &token.Name, &token.AccessKey, &tokenType, &token.CreatedAt, &token.UpdatedAt); err != nil {
-			return nil, err
+		if !iter.Scan(&token.ID, &token.Name, &token.AccessKey, &tokenType, &token.CreatedAt, &token.UpdatedAt) {
+			break
 		}
 		token.TokenType = models.TokenType(tokenType)
 		tokens = append(tokens, token)

--- a/pkg/repositories/scylla/serviceTokens.go
+++ b/pkg/repositories/scylla/serviceTokens.go
@@ -65,12 +65,13 @@ func (s *ScyllaServiceTokenRepository) GetAllServiceTokens(ctx context.Context) 
 
 	estimatedSize := iter.NumRows()
 	tokens := make([]*models.ServiceToken, 0, estimatedSize)
+	scanner := iter.Scanner()
 
-	for {
+	for scanner.Next() {
 		token := &models.ServiceToken{}
 		var tokenType int8
-		if !iter.Scan(&token.ID, &token.Name, &token.AccessKey, &tokenType, &token.CreatedAt, &token.UpdatedAt) {
-			break
+		if err := scanner.Scan(&token.ID, &token.Name, &token.AccessKey, &tokenType, &token.CreatedAt, &token.UpdatedAt); err != nil {
+			return nil, err
 		}
 		token.TokenType = models.TokenType(tokenType)
 		tokens = append(tokens, token)

--- a/pkg/router/main.go
+++ b/pkg/router/main.go
@@ -17,51 +17,60 @@ type ErrorResponse struct {
 	Message string `json:"message" example:"error message"`
 }
 
-var router = gin.Default()
+type router struct {
+	engine *gin.Engine
+	repo   *repositories.ApplicationRepository
+}
 
-var applicationRepository *repositories.ApplicationRepository
+func NewRouter(repo *repositories.ApplicationRepository) *router {
+	return &router{
+		engine: gin.Default(),
+		repo:   repo,
+	}
+}
 
 func Run(ctx context.Context, port int, repo *repositories.ApplicationRepository) {
+	router := NewRouter(repo)
 	initializeRepo(ctx, repo)
-	setupDashboard(ctx)
-	getRoutes()
-	router.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
-	err := router.Run(fmt.Sprintf(":%d", port))
+	setupDashboard(router, ctx)
+	getRoutes(router)
+
+	router.engine.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
+	err := router.engine.Run(fmt.Sprintf(":%d", port))
 	if err != nil {
 		panic(err)
 	}
 }
 
-func setupDashboard(ctx context.Context) {
+func setupDashboard(router *router, ctx context.Context) {
 	dashboardPath := viper.GetString("front-end-path")
-	router.GET("/", func(c *gin.Context) {
+	router.engine.GET("/", func(c *gin.Context) {
 		if c.Query("swagger") == "true" {
 			c.Redirect(302, "/swagger/index.html")
 			return
 		}
 		c.File(dashboardPath + "/index.html")
 	})
-	router.Static("/assets", dashboardPath+"/assets")
-	router.GET("/favicon.ico", func(c *gin.Context) {
+	router.engine.Static("/assets", dashboardPath+"/assets")
+	router.engine.GET("/favicon.ico", func(c *gin.Context) {
 		c.File(dashboardPath + "/favicon.ico")
 	})
 }
 
-func getRoutes() {
-	v1 := router.Group("/v1")
-	addV1Routes(v1)
+func getRoutes(router *router) {
+	v1 := router.engine.Group("/v1")
+	addV1Routes(router, v1)
 }
 
 func initializeRepo(ctx context.Context, repo *repositories.ApplicationRepository) {
-	applicationRepository = repo
-	applicationRepository.ServiceTokens.CreateIndices(ctx)
-	applicationRepository.Buckets.CreateIndices(ctx)
-	applicationRepository.Files.CreateIndices(ctx)
+	repo.ServiceTokens.CreateIndices(ctx)
+	repo.Buckets.CreateIndices(ctx)
+	repo.Files.CreateIndices(ctx)
 }
 
-func addV1Routes(v1 *gin.RouterGroup) {
-	AddServiceTokenRoutes(v1)
-	AddBucketsRoutes(v1)
+func addV1Routes(router *router, v1 *gin.RouterGroup) {
+	AddServiceTokenRoutes(router, v1)
+	AddBucketsRoutes(router, v1)
 	AddFileRoutes(v1)
 	AddFileBlobRoutes(v1)
 }

--- a/pkg/router/utils.go
+++ b/pkg/router/utils.go
@@ -1,0 +1,10 @@
+package router
+
+import "github.com/gin-gonic/gin"
+
+func writeError(c *gin.Context, code int, msg string) {
+	c.JSON(400, ErrorResponse{
+		Code:    400,
+		Message: msg,
+	})
+}

--- a/pkg/router/utils.go
+++ b/pkg/router/utils.go
@@ -3,8 +3,8 @@ package router
 import "github.com/gin-gonic/gin"
 
 func writeError(c *gin.Context, code int, msg string) {
-	c.JSON(400, ErrorResponse{
-		Code:    400,
+	c.JSON(code, ErrorResponse{
+		Code:    code,
 		Message: msg,
 	})
 }


### PR DESCRIPTION
- Removed global variables `gin.Router` and `applicationRepository`.  
- Introduced a `router` struct to encapsulate dependencies:
  ```go
  type router struct {
      engine *gin.Engine
      repo   repositories.ApplicationRepository
  }

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Migrated handlers to a router instance with repository-aware middleware.
  - Standardized HTTP status codes and centralized JSON error responses for consistency.
  - Internal routing reorganization without changing public endpoints.

- Performance
  - Optimized listing of buckets and service tokens for reduced overhead and improved responsiveness.

- Bug Fixes
  - More robust “not found” handling to avoid incorrect errors.
  - Consistent authentication error responses and context propagation for downstream handlers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->