### PR TITLE
Refactor: remove global dependencies and wrap routes in a router struct

### DIFF
--- a/pkg/router/main.go
+++ b/pkg/router/main.go
@@ -17,51 +17,60 @@ type ErrorResponse struct {
 	Message string `json:"message" example:"error message"`
 }
 
-var router = gin.Default()
+type router struct {
+	engine *gin.Engine
+	repo   *repositories.ApplicationRepository
+}
 
-var applicationRepository *repositories.ApplicationRepository
+func NewRouter(repo *repositories.ApplicationRepository) *router {
+	return &router{
+		engine: gin.Default(),
+		repo:   repo,
+	}
+}
 
 func Run(ctx context.Context, port int, repo *repositories.ApplicationRepository) {
+	router := NewRouter(repo)
 	initializeRepo(ctx, repo)
-	setupDashboard(ctx)
-	getRoutes()
-	router.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
-	err := router.Run(fmt.Sprintf(":%d", port))
+	setupDashboard(router, ctx)
+	getRoutes(router)
+
+	router.engine.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
+	err := router.engine.Run(fmt.Sprintf(":%d", port))
 	if err != nil {
 		panic(err)
 	}
 }
 
-func setupDashboard(ctx context.Context) {
+func setupDashboard(router *router, ctx context.Context) {
 	dashboardPath := viper.GetString("front-end-path")
-	router.GET("/", func(c *gin.Context) {
+	router.engine.GET("/", func(c *gin.Context) {
 		if c.Query("swagger") == "true" {
 			c.Redirect(302, "/swagger/index.html")
 			return
 		}
 		c.File(dashboardPath + "/index.html")
 	})
-	router.Static("/assets", dashboardPath+"/assets")
-	router.GET("/favicon.ico", func(c *gin.Context) {
+	router.engine.Static("/assets", dashboardPath+"/assets")
+	router.engine.GET("/favicon.ico", func(c *gin.Context) {
 		c.File(dashboardPath + "/favicon.ico")
 	})
 }
 
-func getRoutes() {
-	v1 := router.Group("/v1")
-	addV1Routes(v1)
+func getRoutes(router *router) {
+	v1 := router.engine.Group("/v1")
+	addV1Routes(router, v1)
 }
 
 func initializeRepo(ctx context.Context, repo *repositories.ApplicationRepository) {
-	applicationRepository = repo
-	applicationRepository.ServiceTokens.CreateIndices(ctx)
-	applicationRepository.Buckets.CreateIndices(ctx)
-	applicationRepository.Files.CreateIndices(ctx)
+	repo.ServiceTokens.CreateIndices(ctx)
+	repo.Buckets.CreateIndices(ctx)
+	repo.Files.CreateIndices(ctx)
 }
 
-func addV1Routes(v1 *gin.RouterGroup) {
-	AddServiceTokenRoutes(v1)
-	AddBucketsRoutes(v1)
+func addV1Routes(router *router, v1 *gin.RouterGroup) {
+	AddServiceTokenRoutes(router, v1)
+	AddBucketsRoutes(router, v1)
 	AddFileRoutes(v1)
 	AddFileBlobRoutes(v1)
 }

--- a/pkg/router/utils.go
+++ b/pkg/router/utils.go
@@ -1,0 +1,10 @@
+package router
+
+import "github.com/gin-gonic/gin"
+
+func writeError(c *gin.Context, code int, msg string) {
+	c.JSON(400, ErrorResponse{
+		Code:    400,
+		Message: msg,
+	})
+}

--- a/pkg/router/utils.go
+++ b/pkg/router/utils.go
@@ -3,8 +3,8 @@ package router
 import "github.com/gin-gonic/gin"
 
 func writeError(c *gin.Context, code int, msg string) {
-	c.JSON(400, ErrorResponse{
-		Code:    400,
+	c.JSON(code, ErrorResponse{
+		Code:    code,
 		Message: msg,
 	})
 }


### PR DESCRIPTION
- Removed global variables `gin.Router` and `applicationRepository`.  
- Introduced a `router` struct to encapsulate dependencies:
  ```go
  type router struct {
      engine *gin.Engine
      repo   repositories.ApplicationRepository
  }
  ```